### PR TITLE
Add a comment

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
   "env": {
     "NODE_ENV": "staging",
     "ENGINE_HOST": "//zhishi-test.herokuapp.com",
-    "VALID_COOKIE": "s%3Alnl1zbETU2GAA4gOhjKk0xY8qOaB8FqE.JLAizY1Ai7DLPHn2MNKcwDjx4UuNyEWKp9UB4ivFIRo"
+    "VALID_COOKIE": "s%3A4mxSVD16wjyFwAuggJkVofxPWnlVaZdC.uPqMO6lAKhtNgneasnbkBy9kLjesW%2BmLGB8DBQEtdWc"
   },
   "formation": {
     "web": {

--- a/app.json
+++ b/app.json
@@ -5,6 +5,7 @@
   },
   "env": {
     "NODE_ENV": "staging",
+    "ENGINE_HOST": "//zhishi-test.herokuapp.com",
     "VALID_COOKIE": "s%3Alnl1zbETU2GAA4gOhjKk0xY8qOaB8FqE.JLAizY1Ai7DLPHn2MNKcwDjx4UuNyEWKp9UB4ivFIRo"
   },
   "formation": {

--- a/app.json
+++ b/app.json
@@ -4,6 +4,8 @@
   "scripts": {
   },
   "env": {
+    "NODE_ENV": "staging",
+    "VALID_COOKIE": "s%3Alnl1zbETU2GAA4gOhjKk0xY8qOaB8FqE.JLAizY1Ai7DLPHn2MNKcwDjx4UuNyEWKp9UB4ivFIRo"
   },
   "formation": {
     "web": {

--- a/tools/distServer.js
+++ b/tools/distServer.js
@@ -12,6 +12,8 @@ var isDeveloping = (
   process.env.NODE_ENV !== 'staging'
 );
 
+// Just to make a change
+
 var port = isDeveloping ? 8080 : process.env.PORT;
 var app = express();
 

--- a/tools/distServer.js
+++ b/tools/distServer.js
@@ -21,7 +21,7 @@ app.use(compression());
 
 if (!isDeveloping) {
   app.use((req, res, next) => {
-    if (!req.headers.host.match(/andela.co/)) {
+    if (!req.headers.host.match(/andela.co/) && !process.env.VALID_COOKIE) {
       return res.redirect(environment.zhishiPermanentSite + req.url);
     }
     next();
@@ -30,7 +30,11 @@ if (!isDeveloping) {
 
 app.use(cookieParser());
 app.use((req, res, next) => {
-  res.cookie('andela_cookie', req.cookies['andela:session']);
+  if (process.env.VALID_COOKIE) {
+    res.cookie('andela_cookie', process.env.VALID_COOKIE);
+  } else {
+    res.cookie('andela_cookie', req.cookies['andela:session']);
+  }
   res.cookie(CVar.apiUrl, process.env.ENGINE_HOST);
   next();
 });


### PR DESCRIPTION
#### Preset a valid Andela Cookie in PR Environment
Given that the auto created heroku review apps are not on Andela domain, they will not be able to access the Andela cookie for authentication. This PR adds settings in the `app.json` file to preset a valid cookie as an environment variable and read the Andela cookie from this env (`VALID_COOKIE`) when it's available.
